### PR TITLE
Try all authentication backends to attempt to Auth

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -20,6 +20,10 @@ def pytest_configure(config):
     from django.conf import settings
 
     settings.configure(
+        AUTHENTICATION_BACKENDS=[
+            'tests.base.FooPasswordBackend',
+            'tests.base.StubPasswordBackend',
+        ],
         DEBUG=True,
         DATABASE_ENGINE='sqlite3',
         DATABASES={

--- a/sudo/forms.py
+++ b/sudo/forms.py
@@ -6,6 +6,7 @@ sudo.forms
 :license: BSD, see LICENSE for more details.
 """
 from django import forms
+from django.contrib import auth
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -20,6 +21,7 @@ class SudoForm(forms.Form):
         super(SudoForm, self).__init__(*args, **kwargs)
 
     def clean_password(self):
-        if not self.user.check_password(self.data['password']):
-            raise forms.ValidationError(_('Incorrect password'))
-        return self.data['password']
+        if auth.authenticate(username=self.user.username,
+                             password=self.data['password']):
+            return self.data['password']
+        raise forms.ValidationError(_('Incorrect password'))

--- a/tests/base.py
+++ b/tests/base.py
@@ -7,6 +7,23 @@ from django.test import RequestFactory
 from django.contrib.auth.models import User, AnonymousUser
 
 
+class StubPasswordBackend(object):
+    """ Stub backend
+
+    Always authenticates when the password matches self.password
+
+    """
+    password = "stub"
+
+    def authenticate(self, username, password):
+        if password == self.password:
+            return User()
+
+
+class FooPasswordBackend(StubPasswordBackend):
+    password = "foo"
+
+
 class BaseTestCase(unittest.TestCase):
     def setUp(self):
         self.request = self.get('/foo')
@@ -24,5 +41,4 @@ class BaseTestCase(unittest.TestCase):
 
     def login(self):
         user = User()
-        user.set_password('foo')
         self.setUser(user)

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -22,12 +22,24 @@ class SudoFormTestCase(BaseTestCase):
             SudoForm(self.user, {'password': 'foo'}).is_valid()
         )
 
+    def test_integration_secondary_auth_valid_password(self):
+        self.assertTrue(
+            SudoForm(self.user, {'password': 'stub'}).is_valid()
+        )
+
     def test_clean_password_invalid_password(self):
         with self.assertRaises(ValidationError):
             SudoForm(self.user, {'password': 'lol'}).clean_password()
 
     def test_clean_password_valid_password(self):
         password = 'foo'
+        self.assertEqual(
+            SudoForm(self.user, {'password': password}).clean_password(),
+            password
+        )
+
+    def test_clean_password_secondary_auth_valid_password(self):
+        password = 'stub'
         self.assertEqual(
             SudoForm(self.user, {'password': password}).clean_password(),
             password


### PR DESCRIPTION
Not all authentication backends store the password on the User object,
notibly LDAP and AD authentication.

Django Users require both a username and a password to auth, so update
the test case to store a username, and save it so that the
django.contrib.auth.backends.ModelBackend can look it up in the
database.
