### PR TITLE
SudoMixin for class-based views

### DIFF
--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -25,6 +25,24 @@ Once we have ``django-sudo`` :doc:`installed </getting-started/index>` and
     redirected to a page and prompted for their password. After entering their password, they'll be
     redirected back to this page to continue on what they were trying to do.
 
+.. class:: sudo.mixins.SudoMixin
+
+    ``SudoMixin`` provides an easy way to sudo a class-based view. Any view
+    that inherits from this mixin is automatically wrapped by the
+    ``@sudo_required`` decorator.
+
+    This works well with the ``LoginRequiredMixin`` from
+    `django-braces <https://django-braces.rtfd.org/>`_:
+
+    .. code-block:: python
+
+        from django.views import generic
+        from braces.views import LoginRequiredMixin
+        from sudo.mixins import SudoMixin
+
+        class SuperSecretView(LoginRequiredMixin, SudoMixin, generic.TemplateView):
+            template_name = 'secret/super-secret.html'
+
 .. method:: request.is_sudo()
 
 Returns a boolean to indicate if the current request is in sudo mode or not. This gets added on by
@@ -36,7 +54,7 @@ the :class:`~sudo.middleware.SudoMiddleware`. This is an shortcut for calling
     By default, you just need to add this into your ``MIDDLEWARE_CLASSES`` list.
 
     .. method:: has_sudo_privileges(self, request)
-    
+
     Subclass and override :func:`~sudo.middleware.SudoMiddleware.has_sudo_privileges` if you'd like
     to override the default behavior of :func:`request.is_sudo() <request.is_sudo()>`.
 

--- a/sudo/mixins.py
+++ b/sudo/mixins.py
@@ -1,0 +1,8 @@
+from sudo.decorators import sudo_required
+
+
+class SudoMixin(object):
+    @classmethod
+    def as_view(cls, **initkwargs):
+        view = super(SudoMixin, cls).as_view(**initkwargs)
+        return sudo_required(view)

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -1,0 +1,24 @@
+from .base import BaseTestCase
+from django.http import HttpResponse
+from django.views import generic
+from sudo.mixins import SudoMixin
+
+
+class FooView(SudoMixin, generic.View):
+    def get(self, request):
+        return HttpResponse()
+
+foo = FooView.as_view()
+
+
+class SudoMixinTestCase(BaseTestCase):
+    def test_is_sudo(self):
+        self.request.is_sudo = lambda: True
+        response = foo(self.request)
+        self.assertEqual(response.status_code, 200)
+
+    def test_is_not_sudo(self):
+        self.request.is_sudo = lambda: False
+        response = foo(self.request)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], '/sudo/?next=/foo')


### PR DESCRIPTION
I primarily use class-based views, and it's really handy to be able to drop a `SudoMixin` into views I want to protect. It would be nice to have this built into django-sudo.

Tests and documentation included.