### PR TITLE
Add request to default context (fixes GH-7)

### DIFF
--- a/sudo/views.py
+++ b/sudo/views.py
@@ -95,6 +95,7 @@ def sudo(request, template_name='sudo/sudo.html', extra_context=None):
             return HttpResponseRedirect(redirect_to)
 
     context = {
+        'request': request,
         'form': form,
         REDIRECT_FIELD_NAME: redirect_to,
     }


### PR DESCRIPTION
This is opinionated. We could just pass it in a subclass, but it seems like an ok default.