### PR TITLE
Add redirect to requested page upon entering sudo mode.

### DIFF
--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -46,6 +46,10 @@ By default, all of the settings are optional and define sane and secure defaults
     The form to use within the ``sudo`` view. Override if you want to change the behavior or add
     additional fields. *Default: sudo.forms.SudoForm*
 
+``SUDO_REDIRECT_TO_FIELD_NAME``
+    The name of the session attribute used to preserve the redirect destination
+    between the original page request and successful sudo login. *Default: sudo_redirect_to*
+
 Set up URLs
 ~~~~~~~~~~~
 

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -19,7 +19,7 @@ environment. After creating an environment, install all dep dependencies with:
 
 .. code-block:: console
 
-    $ pip install -e dev-requirements.txt
+    $ pip install -r dev-requirements.txt
 
 Running Tests
 ~~~~~~~~~~~~~

--- a/sudo/settings.py
+++ b/sudo/settings.py
@@ -41,3 +41,7 @@ COOKIE_SALT = getattr(settings, 'SUDO_COOKIE_SALT', '')
 # The form to use within the ``sudo`` view. Override if you want to add
 # additional fields or different behavior.
 SUDO_FORM = getattr(settings, 'SUDO_FORM', 'sudo.forms.SudoForm')
+
+# The name of the session attribute used to preserve the redirect destination
+# between the original page request and successful sudo login.
+REDIRECT_TO_FIELD_NAME = getattr(settings, 'SUDO_REDIRECT_TO_FIELD_NAME', 'sudo_redirect_to')

--- a/sudo/views.py
+++ b/sudo/views.py
@@ -91,14 +91,14 @@ def sudo(request, template_name='sudo/sudo.html', extra_context=None):
         return HttpResponseRedirect(redirect_to)
 
     if request.method == 'GET':
-        request.session['REDIRECT_TO_FIELD_NAME'] = redirect_to
+        request.session[REDIRECT_TO_FIELD_NAME] = redirect_to
 
     form = SudoForm(request.user, request.POST or None)
     if request.method == 'POST':
         if form.is_valid():
             grant_sudo_privileges(request)
             # Restore the redirect destination from the GET request
-            redirect_to = request.session.pop('REDIRECT_TO_FIELD_NAME', redirect_to)
+            redirect_to = request.session.pop(REDIRECT_TO_FIELD_NAME, redirect_to)
             # Double check we're not redirecting to other sites
             if not is_safe_url(url=redirect_to, host=request.get_host()):
                 redirect_to = resolve_url(REDIRECT_URL)

--- a/sudo/views.py
+++ b/sudo/views.py
@@ -24,7 +24,8 @@ from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
 
-from sudo.settings import REDIRECT_FIELD_NAME, REDIRECT_URL, SUDO_FORM
+from sudo.settings import (REDIRECT_FIELD_NAME, REDIRECT_URL, SUDO_FORM,
+                           REDIRECT_TO_FIELD_NAME)
 from sudo.utils import grant_sudo_privileges
 
 FormPath, FormClass = '.'.join(SUDO_FORM.split('.')[:-1]), SUDO_FORM.split('.')[-1]
@@ -90,13 +91,17 @@ def sudo(request, template_name='sudo/sudo.html', extra_context=None):
         return HttpResponseRedirect(redirect_to)
 
     if request.method == 'GET':
-        request.session['redirect_to'] = redirect_to
+        request.session['REDIRECT_TO_FIELD_NAME'] = redirect_to
 
     form = SudoForm(request.user, request.POST or None)
     if request.method == 'POST':
         if form.is_valid():
             grant_sudo_privileges(request)
-            redirect_to = request.session.pop('redirect_to', redirect_to)
+            # Restore the redirect destination from the GET request
+            redirect_to = request.session.pop('REDIRECT_TO_FIELD_NAME', redirect_to)
+            # Double check we're not redirecting to other sites
+            if not is_safe_url(url=redirect_to, host=request.get_host()):
+                redirect_to = resolve_url(REDIRECT_URL)
             return HttpResponseRedirect(redirect_to)
 
     context = {

--- a/sudo/views.py
+++ b/sudo/views.py
@@ -81,6 +81,7 @@ def sudo(request, template_name='sudo/sudo.html', extra_context=None):
     them back to ``next``.
     """
     redirect_to = request.GET.get(REDIRECT_FIELD_NAME, REDIRECT_URL)
+
     # Make sure we're not redirecting to other sites
     if not is_safe_url(url=redirect_to, host=request.get_host()):
         redirect_to = resolve_url(REDIRECT_URL)
@@ -88,10 +89,14 @@ def sudo(request, template_name='sudo/sudo.html', extra_context=None):
     if request.is_sudo():
         return HttpResponseRedirect(redirect_to)
 
+    if request.method == 'GET':
+        request.session['redirect_to'] = redirect_to
+
     form = SudoForm(request.user, request.POST or None)
     if request.method == 'POST':
         if form.is_valid():
             grant_sudo_privileges(request)
+            redirect_to = request.session.pop('redirect_to', redirect_to)
             return HttpResponseRedirect(redirect_to)
 
     context = {

--- a/tests/views.py
+++ b/tests/views.py
@@ -78,6 +78,24 @@ class SudoViewTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response['Location'], REDIRECT_URL)
 
+    def test_redirect_after_successful_get_and_post(self):
+        self.login()
+        self.request.is_sudo = lambda: False
+        self.request.method = 'GET'
+        self.request.GET = {REDIRECT_FIELD_NAME: '/foobar'}
+        sudo(self.request)
+
+        self.request, self.request.session = self.post('/foo'), self.request.session
+        self.login()
+        self.request.is_sudo = lambda: False
+        self.request.method = 'POST'
+        self.request.POST = {'password': 'foo'}
+        self.request.csrf_processing_done = True
+        response = sudo(self.request)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], '/foobar')
+        self.assertNotEqual(response['Location'], REDIRECT_URL)
+
     def test_render_form_with_bad_password(self):
         self.login()
         self.request.is_sudo = lambda: False

--- a/tests/views.py
+++ b/tests/views.py
@@ -95,6 +95,7 @@ class SudoViewTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response['Location'], '/foobar')
         self.assertNotEqual(response['Location'], REDIRECT_URL)
+        self.assertFalse('redirect_to' in self.request.session)
 
     def test_render_form_with_bad_password(self):
         self.login()


### PR DESCRIPTION
Answering the question from #9 - I found the redirection to a single page upon successful sudo login to be counterintuitive, so the desired url is saved as a session parameter during the get request.