### PR TITLE
Add a sudo mode disable setting to make view testing manageable.

### DIFF
--- a/sudo/decorators.py
+++ b/sudo/decorators.py
@@ -8,6 +8,7 @@ sudo.decorators
 from functools import wraps
 
 from sudo.views import redirect_to_sudo
+import sudo
 
 
 def sudo_required(func):
@@ -24,4 +25,21 @@ def sudo_required(func):
         if not request.is_sudo():
             return redirect_to_sudo(request.get_full_path())
         return func(request, *args, **kwargs)
+    return inner
+
+
+def sudo_disabled(func):
+    """
+    Disables sudo for for a given function to make view
+    testing manageable.
+
+    >>> class SomeAppViewsTest(TestCase):
+    >>>    @sudo_disabled
+    >>>    def test_secure_page(self):
+    >>>        ...
+    """
+    @wraps(func)
+    def inner(cls):
+        sudo.settings.SUDO_DISABLE = True
+        func(cls)
     return inner

--- a/sudo/settings.py
+++ b/sudo/settings.py
@@ -45,3 +45,6 @@ SUDO_FORM = getattr(settings, 'SUDO_FORM', 'sudo.forms.SudoForm')
 # The name of the session attribute used to preserve the redirect destination
 # between the original page request and successful sudo login.
 REDIRECT_TO_FIELD_NAME = getattr(settings, 'SUDO_REDIRECT_TO_FIELD_NAME', 'sudo_redirect_to')
+
+# Testing setting, disables sudo to facilitate view testing using django test client
+SUDO_DISABLE = getattr(settings, 'SUDO_DISABLE', False)

--- a/sudo/utils.py
+++ b/sudo/utils.py
@@ -48,6 +48,9 @@ def has_sudo_privileges(request):
     """
     Check if a request is allowed to perform sudo actions
     """
+    from sudo.settings import SUDO_DISABLE
+    if SUDO_DISABLE:
+        return True
     if getattr(request, '_sudo', None) is None:
         try:
             request._sudo = (

--- a/sudo/views.py
+++ b/sudo/views.py
@@ -13,7 +13,7 @@ except ImportError:  # pragma: no cover
 
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect, QueryDict
+from django.http import HttpResponseRedirect, QueryDict, HttpResponse
 from django.template.response import TemplateResponse
 try:
     import importlib
@@ -25,7 +25,7 @@ from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
 
 from sudo.settings import (REDIRECT_FIELD_NAME, REDIRECT_URL, SUDO_FORM,
-                           REDIRECT_TO_FIELD_NAME)
+                           REDIRECT_TO_FIELD_NAME, SUDO_DISABLE)
 from sudo.utils import grant_sudo_privileges
 
 FormPath, FormClass = '.'.join(SUDO_FORM.split('.')[:-1]), SUDO_FORM.split('.')[-1]
@@ -82,6 +82,9 @@ def sudo(request, template_name='sudo/sudo.html', extra_context=None):
     them back to ``next``.
     """
     redirect_to = request.GET.get(REDIRECT_FIELD_NAME, REDIRECT_URL)
+
+    if SUDO_DISABLE:
+        return HttpResponse(redirect_to)
 
     # Make sure we're not redirecting to other sites
     if not is_safe_url(url=redirect_to, host=request.get_host()):


### PR DESCRIPTION
Adding @sudo_required to views is likely to break views unit tests using the django test client. Adding a setting that makes the @sudo_required transparent for testing purposes - allowing to test the view functionality without extra headaches.
