### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,7 +5,7 @@ Security
 ~~~~~~~~
 
 If you are submitting a security vulnerability, please don't submit a public issue or pull request.
-Instead, review our `security page <https://django-sudo.readthedocs.org/en/latest/security/index.html>`_
+Instead, review our `security page <https://django-sudo.readthedocs.io/en/latest/security/index.html>`_
 for more information.
 
 Tests

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,6 @@ Compatibility
 
 Resources
 ~~~~~~~~~
-* `Documentation <https://django-sudo.readthedocs.org/>`_
-* `Security <https://django-sudo.readthedocs.org/en/latest/security/index.html>`_
-* `Changelog <https://django-sudo.readthedocs.org/en/latest/changelog/index.html>`_
+* `Documentation <https://django-sudo.readthedocs.io/>`_
+* `Security <https://django-sudo.readthedocs.io/en/latest/security/index.html>`_
+* `Changelog <https://django-sudo.readthedocs.io/en/latest/changelog/index.html>`_

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -32,7 +32,7 @@ Once we have ``django-sudo`` :doc:`installed </getting-started/index>` and
     ``@sudo_required`` decorator.
 
     This works well with the ``LoginRequiredMixin`` from
-    `django-braces <https://django-braces.rtfd.org/>`_:
+    `django-braces <https://django-braces.readthedocs.io/>`_:
 
     .. code-block:: python
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.