### PR TITLE
Dont treat https:\d+ URLs as safe

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -122,6 +122,7 @@ class IsSafeUrlTestCase(BaseTestCase):
             ('', ''),
             ('http://mattrobenolt.com/', 'example.com'),
             ('///example.com/', None),
+            ('https:1029415385', 'example.com'),
             ('ftp://example.com', 'example.com'),
             ('http://example.com\@mattrobenolt.com', 'example.com'),  # noqa: W605
             ('http:///example.com', 'example.com'),


### PR DESCRIPTION
Don't allow redirects to targets like `https:1029415385` as while they look like relative paths to urlparse, they are handled as host + IP redirects in browsers.